### PR TITLE
Fix: Sort issue with new game button

### DIFF
--- a/util/gameutilities.js
+++ b/util/gameutilities.js
@@ -241,7 +241,7 @@ luckyDivisor.util.game.restart = function() {
 	
 	luckyDivisor.util.game.beforePlayInit();
 	
-	initialisePnCubeCreationRecord();
+	luckyDivisor.util.initialisePnCubeCreationRecord();
 	
 	luckyDivisor.global.numberOfPnCubeCreated = 0;
 	


### PR DESCRIPTION
What was happening before was the following, the new game button does not actually restart the game. This was because a call recreate the pn cube comes back with an error. That specifc function being invoked was initially global, but later on I moved it to utilitites. That was the cause for the issue.